### PR TITLE
feat: allow comments on Drafts, too

### DIFF
--- a/rpc/api.py
+++ b/rpc/api.py
@@ -435,12 +435,14 @@ class RfcToBeCommentViewSet(
         if dt_person is None or not hasattr(dt_person, "rpcperson"):
             raise PermissionDenied
 
+        # Get ready to save...
+        save_kwargs = {"by": dt_person}
+
         # First, see if we have an RfcToBe for the draft
         draft_name = self.kwargs["draft_name"]
         rfc_to_be = RfcToBe.objects.filter(
             draft__name=draft_name
         ).first()
-        save_kwargs = {}
         if rfc_to_be is not None:
             save_kwargs["rfc_to_be"] = rfc_to_be
         else:
@@ -450,13 +452,16 @@ class RfcToBeCommentViewSet(
                 save_kwargs["document"] = draft
         if not save_kwargs:
             raise NotFound
-        save_kwargs["by"] = dt_person
         # todo permissions check
         serializer.save(**save_kwargs)
 
     @staticmethod
     @with_rpcapi
     def _draft_by_name(draft_name, *, rpcapi: rpcapi_client.DefaultApi):
+        """Get a datatracker Document for a draft given its name
+
+        n.b., creates a Document object if needed
+        """
         drafts = rpcapi.get_drafts_by_names([draft_name])
         draft_info = drafts.get(draft_name, None)
         if draft_info is None:


### PR DESCRIPTION
This extends the not-yet-merged comments API to allow comments on both RfcToBe and datatracker Documents through the same interface.

It's a WIP - this runs against an important sync problem for purple's `datatracker.Document` model. The `RpcDocumentComment` model requires an FK to either an `rpc.RfcToBe` or a `datatracker.Document` instance. To make this work, the class creates a `Document`. This represents to purple the existence of a draft over at the datatracker, and some of the properties of that draft may change over time.

Not a new issue, but so far we only create the `Document` models when importing a draft to create an `RfcToBe`, which will generally mean the properties are not going to change. We'll need to address this in general, just calling it out here.
